### PR TITLE
Convert rani-ukamble-group/reusable_files_application to GitHub Actions

### DIFF
--- a/.github/workflows/reusable_files_application.yml
+++ b/.github/workflows/reusable_files_application.yml
@@ -1,0 +1,31 @@
+name: rani-ukamble-group/reusable_files_application
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Building the application..."
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Running tests.."


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/rani-ukamble-group/reusable_files_application) :tada: